### PR TITLE
Fix travis to run extended tests and update clusterrole to work with OpenShift 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 matrix:
   include:
   - go: 1.8
-    env: AUTHORITATIVE=true OPENSHIFT_VERSIONS="v1.4.1 v1.5.1 v3.6.0-alpha.2"
+    env: AUTHORITATIVE=true OPENSHIFT_VERSIONS="v1.4.1 v1.5.1 v3.6.0"
     sudo: required
     services:
      - docker
@@ -31,7 +31,7 @@ before_install:
     sudo mv ${tmp} /etc/default/docker
     sudo mount --make-shared /
     sudo service docker restart
-    version="v3.6.0-alpha.2" commitId="3c221d5" && curl -L https://github.com/openshift/origin/releases/download/${version}/openshift-origin-client-tools-${version}-${commitId}-linux-64bit.tar.gz | tar -f - -x -z --strip-components=1 -C ${GOPATH}/bin/ openshift-origin-client-tools-${version}-${commitId}-linux-64bit/oc
+    version="v3.6.0" commitId="c4dd4cf" && curl -L https://github.com/openshift/origin/releases/download/${version}/openshift-origin-client-tools-${version}-${commitId}-linux-64bit.tar.gz | tar -f - -x -z --strip-components=1 -C ${GOPATH}/bin/ openshift-origin-client-tools-${version}-${commitId}-linux-64bit/oc
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
     sed -e 's/imagePullPolicy: IfNotPresent/imagePullPolicy: Never/' -e 's/value: "8"/value: "9"/' ./deploy/deploymentconfig-letsencrypt-staging.yaml > ${deploymentFile}
     grep -q 'imagePullPolicy: Never' ${deploymentFile}
     [[ ! -z "${OPENSHIFT_VERSIONS}" ]]
+    make -j64 test-extended GOFLAGS="-i -race"
     for version in ${OPENSHIFT_VERSIONS}; do
       oc cluster up --version=${version}
       oc new-project acme-asdf
@@ -73,7 +74,7 @@ script:
       sleep 10
       oc status -v
       oc new-project test-asdf
-      make -j64 test-extended GOFLAGS="-i -race" GO_ET_KUBECONFIG=~/.kube/config GO_ET_DOMAIN=${domain}
+      make -j64 test-extended GOFLAGS="-race" GO_ET_KUBECONFIG=~/.kube/config GO_ET_DOMAIN=${domain} || (oc logs dc/acme-controller -n acme-asdf; false)
       oc logs dc/acme-controller -n acme-asdf
       oc cluster down
     done

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -4,11 +4,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - "route.openshift.io"
   resources:
   - endpoints
   - endpoints/restricted
   - events
   - routes
+  - routes/custom-host
+  - routes/status
   - secrets
   - services
   verbs:

--- a/pkg/openshift/challengeexposers/route.go
+++ b/pkg/openshift/challengeexposers/route.go
@@ -222,7 +222,7 @@ func (r *Route) Expose(a *acmelib.Client, domain string, token string) error {
 							log.Warnf("route challenge exposer: creating route %s/%s failed because of collision: %s", tmpName, namespace, err)
 							continue
 						} else {
-							log.Errorf("route challenge exposer: creating route %s/%s failed: %s", tmpName, namespace, err)
+							log.Errorf("route challenge exposer: creating route %s/%s failed: %s; raw: %s", tmpName, namespace, err, rawRoute)
 							return
 						}
 					}

--- a/test/extended/openshift/extended_test.go
+++ b/test/extended/openshift/extended_test.go
@@ -109,7 +109,7 @@ func TestBasic(t *testing.T) {
 	}
 	defer w.Stop()
 
-	timeout := 30 * time.Second
+	timeout := 60 * time.Second
 loop:
 	for {
 		select {


### PR DESCRIPTION
- Fix `go test -i` mistake in tests and actually run them :)
- Raise test timeout from 30 s to 60 s to achive consistent results
- Update clusterrole to work with OpenShift 3.6 (due to https://github.com/openshift/origin/pull/13905) fixes https://github.com/tnozicka/openshift-acme/issues/8