### PR TITLE
Create challenge route with tls

### DIFF
--- a/pkg/openshift/challengeexposers/route.go
+++ b/pkg/openshift/challengeexposers/route.go
@@ -191,6 +191,11 @@ func (r *Route) Expose(a *acmelib.Client, domain string, token string) error {
 			route.Spec.To.Kind = "Service"
 			route.Spec.To.Name = tmpName
 			route.Spec.To.Weight = 100
+			if route.Spec.Tls == nil {
+				route.Spec.Tls = &oapi.TlsConfig{}
+			}
+			route.Spec.Tls.Termination = "edge"
+			route.Spec.Tls.InsecureEdgeTerminationPolicy = "Allow"
 		}
 
 		for i := 1; i <= maxTries; i++ {


### PR DESCRIPTION
Without tls, if the main route already has tls (ie. renewal) then the router will ignore the challenge route.
Leading to failed renewals

Fixes #11