### PR TITLE
Fix updating NotBefore and NotAfter for updated certificates on Routes and Secrets

### DIFF
--- a/pkg/openshift/controllers/route/object.go
+++ b/pkg/openshift/controllers/route/object.go
@@ -130,8 +130,8 @@ func (o *RouteObject) UpdateCertificate(c *cert.Certificate) error {
 		secret.Annotations = map[string]string{}
 	}
 	secret.Annotations["kubernetes.io/tls-acme.last-update-time"] = time.Now().Format(time.RFC3339)
-	secret.Annotations["kubernetes.io/tls-acme.valid-not-before"] = time.Now().Format(time.RFC3339)
-	secret.Annotations["kubernetes.io/tls-acme.valid-not-after"] = time.Now().Format(time.RFC3339)
+	secret.Annotations["kubernetes.io/tls-acme.valid-not-before"] = c.Certificate.NotBefore.Format(time.RFC3339)
+	secret.Annotations["kubernetes.io/tls-acme.valid-not-after"] = c.Certificate.NotAfter.Format(time.RFC3339)
 	if secret.Data == nil {
 		secret.Data = map[string][]byte{}
 	}
@@ -157,8 +157,8 @@ func (o *RouteObject) UpdateCertificate(c *cert.Certificate) error {
 		route.Annotations = map[string]string{}
 	}
 	route.Annotations["kubernetes.io/tls-acme.last-update-time"] = time.Now().Format(time.RFC3339)
-	secret.Annotations["kubernetes.io/tls-acme.valid-not-before"] = time.Now().Format(time.RFC3339)
-	secret.Annotations["kubernetes.io/tls-acme.valid-not-after"] = time.Now().Format(time.RFC3339)
+	secret.Annotations["kubernetes.io/tls-acme.valid-not-before"] = c.Certificate.NotBefore.Format(time.RFC3339)
+	secret.Annotations["kubernetes.io/tls-acme.valid-not-after"] = c.Certificate.NotAfter.Format(time.RFC3339)
 	if route.Spec.Tls == nil {
 		route.Spec.Tls = &oapi.TlsConfig{}
 	}


### PR DESCRIPTION
Fixes: https://github.com/tnozicka/openshift-acme/issues/17

@germansosa @andrewklau could you please test it if this will fix https://github.com/tnozicka/openshift-acme/issues/17. sorry about that. (I am planing to write extended tests for renewals so this doesn't happen.)