### PR TITLE
Remove projects from clusterrole

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -20,7 +20,6 @@ rules:
   - ""
   resources:
   - namespaces
-  - projects
   verbs:
   - get
   - list


### PR DESCRIPTION
Don't think it needs the "projects" resource, otherwise it'll need to have the apiGroups "project.openshift.io"