### PR TITLE
Normalize temporary exposing name to avoid validation differences between Route's name and other objects whose names are based on it

### DIFF
--- a/pkg/controllers/route/exposer_test.go
+++ b/pkg/controllers/route/exposer_test.go
@@ -1,0 +1,41 @@
+package route
+
+import (
+	"reflect"
+	"testing"
+
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestCreateTemporaryExposerName(t *testing.T) {
+	tt := []struct {
+		routeName    string
+		expectErrors []string
+	}{
+		{
+			routeName:    "dns-label",
+			expectErrors: nil,
+		},
+		{
+			routeName:    "dns.subdomain",
+			expectErrors: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run("", func(t *testing.T) {
+			// Sanity - test if it's a valid Route name
+			err := kvalidation.IsDNS1123Subdomain(tc.routeName)
+			if err != nil {
+				t.Errorf("invalid Route name %q: %v", tc.routeName, err)
+			}
+
+			tmpExposerName := createTemporaryExposerName(tc.routeName)
+
+			gotErrors := kvalidation.IsDNS1035Label(tmpExposerName)
+			if !reflect.DeepEqual(gotErrors, tc.expectErrors) {
+				t.Errorf("expected %v, got %v", tc.expectErrors, gotErrors)
+			}
+		})
+	}
+}

--- a/test/e2e/openshift/routes/routes.go
+++ b/test/e2e/openshift/routes/routes.go
@@ -147,7 +147,10 @@ var _ = g.Describe("Routes", func() {
 		g.By("creating new Route without TLS")
 		route := &routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
+				// Test that the exposing goes fine even with a subdomain in name as other objects
+				// whose name might be based on this one may not support it if not normalized.
+				// See https://github.com/tnozicka/openshift-acme/issues/50
+				Name: "subdomain.test",
 				Annotations: map[string]string{
 					"kubernetes.io/tls-acme": "true",
 				},


### PR DESCRIPTION
Fixes https://github.com/tnozicka/openshift-acme/issues/50