### PR TITLE
support http/https proxies #57

### DIFF
--- a/pkg/controllers/route/exposer.go
+++ b/pkg/controllers/route/exposer.go
@@ -339,6 +339,7 @@ func (e *Exposer) Expose(c *acme.Client, domain string, token string) error {
 		},
 		func() (bool, error) {
 			tr := &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},


### PR DESCRIPTION
As mentioned in [issue 57](https://github.com/tnozicka/openshift-acme/issues/57), http/https proxies are not used with current http.transport implementation in exposer.go.
Please find attached a proposed fix, validated in my environment.
With this patch, proxy is still optional and will be used only if http_proxy, https_proxy and no_proxy (or uppercase version) environment variables are defined in the execution environment of the process.