### PR TITLE
Avoid secret collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ metadata:
     kubernetes.io/tls-acme: "true"
 ```
 
+### Configure ACME
+You can use the following annotations to configure your route/certificate:
+
+| Annotation | Description |
+| ---------- | ----------- |
+| `kubernetes.io/tls-acme-secret-name` | Define the name of the secret used to store the certificate. Per default, the name of the route will be used. |
+
 ## Screencast
 [![openshift-acme screencast](https://asciinema.org/a/175706.png)](https://asciinema.org/a/175706)
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -5,4 +5,7 @@ const (
 	TlsAcmePausedAnnotation             = "kubernetes.io/tls-acme-paused"
 	AcmeAwaitingAuthzUrlAnnotation      = "kubernetes.io/tls-acme-awaiting-authorization-at-url"
 	AcmeAwaitingAuthzUrlOwnerAnnotation = "kubernetes.io/tls-acme-awaiting-authorization-owner"
+	// TlsSecretNameAnnotation describes the annotation used to determine the
+	// name of the secret used to store the TLS certificate obtained
+	TlsSecretNameAnnotation = "kubernetes.io/tls-acme-secret-name"
 )

--- a/pkg/controllers/route/route.go
+++ b/pkg/controllers/route/route.go
@@ -610,7 +610,10 @@ func (rc *RouteController) handle(key string) error {
 
 func (rc *RouteController) syncSecret(routeReadOnly *routev1.Route) error {
 	// TODO: consider option of choosing a oldSecret name using an annotation
-	secretName := routeReadOnly.Name
+	secretName := routeReadOnly.Annotations[api.TlsSecretNameAnnotation]
+	if secretName == "" {
+		secretName = routeReadOnly.Name
+	}
 
 	secretExists := true
 	oldSecret, err := rc.secretLister.Secrets(routeReadOnly.Namespace).Get(secretName)

--- a/pkg/controllers/route/route.go
+++ b/pkg/controllers/route/route.go
@@ -609,7 +609,6 @@ func (rc *RouteController) handle(key string) error {
 }
 
 func (rc *RouteController) syncSecret(routeReadOnly *routev1.Route) error {
-	// TODO: consider option of choosing a oldSecret name using an annotation
 	secretName := routeReadOnly.Annotations[api.TlsSecretNameAnnotation]
 	if secretName == "" {
 		secretName = routeReadOnly.Name


### PR DESCRIPTION
This patch adds support for the `kubernetes.io/tls-acme-secret-name`
annotation. When set, the secret used to store the TLS certificate will
be named after its value.

If unset, the name of the route will be used instead.

Example usage:

    oc annotate route/myapp \
        kubernetes.io/tls-acme="true" \
        kubernetes.io/tls-acme-secret-name="myapp-tls-cert"

This will obtain a TLS certificate and store it in a secret called
`myapp-tls-cert`.

Fixes: #64

```release-note
Add the option to configure the TLS secret name via an annotation.
```