### PR TITLE
Migrate manifests from legacy to API groups

### DIFF
--- a/deploy/.diffs/live-staging-cluster-wide.diff
+++ b/deploy/.diffs/live-staging-cluster-wide.diff
@@ -12,7 +12,7 @@ diff -r deploy/letsencrypt-live/cluster-wide/README.md deploy/letsencrypt-stagin
 ---
 > oc create -fhttps://raw.githubusercontent.com/tnozicka/openshift-acme/master/deploy/letsencrypt-staging/cluster-wide/{clusterrole,serviceaccount,imagestream,deployment}.yaml
 diff -r deploy/letsencrypt-live/cluster-wide/deployment.yaml deploy/letsencrypt-staging/cluster-wide/deployment.yaml
-32c32
+34c34
 <           value: "https://acme-v01.api.letsencrypt.org/directory"
 ---
 >           value: "https://acme-staging.api.letsencrypt.org/directory"

--- a/deploy/.diffs/live-staging-single-namespace.diff
+++ b/deploy/.diffs/live-staging-single-namespace.diff
@@ -12,7 +12,7 @@ diff -r deploy/letsencrypt-live/single-namespace/README.md deploy/letsencrypt-st
 ---
 > oc create -fhttps://raw.githubusercontent.com/tnozicka/openshift-acme/master/deploy/letsencrypt-staging/single-namespace/{role,serviceaccount,imagestream,deployment}.yaml
 diff -r deploy/letsencrypt-live/single-namespace/deployment.yaml deploy/letsencrypt-staging/single-namespace/deployment.yaml
-32c32
+34c34
 <           value: "https://acme-v01.api.letsencrypt.org/directory"
 ---
 >           value: "https://acme-staging.api.letsencrypt.org/directory"

--- a/deploy/.diffs/staging-deployment.yaml.diff
+++ b/deploy/.diffs/staging-deployment.yaml.diff
@@ -1,4 +1,4 @@
-34a35,49
+36a37,51
 >         - name: OPENSHIFT_ACME_NAMESPACE
 >           valueFrom:
 >             fieldRef:

--- a/deploy/letsencrypt-live/cluster-wide/clusterrole.yaml
+++ b/deploy/letsencrypt-live/cluster-wide/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-live/cluster-wide/deployment.yaml
+++ b/deploy/letsencrypt-live/cluster-wide/deployment.yaml
@@ -1,13 +1,15 @@
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openshift-acme
   labels:
     app: openshift-acme
   annotations:
-    image.alpha.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[0].image"}]'
     image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"openshift-acme\")].image"}]'
 spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
   replicas: 1
   strategy:
     type: Recreate

--- a/deploy/letsencrypt-live/cluster-wide/imagestream.yaml
+++ b/deploy/letsencrypt-live/cluster-wide/imagestream.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-live/single-namespace/deployment.yaml
+++ b/deploy/letsencrypt-live/single-namespace/deployment.yaml
@@ -1,13 +1,15 @@
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openshift-acme
   labels:
     app: openshift-acme
   annotations:
-    image.alpha.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[0].image"}]'
     image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"openshift-acme\")].image"}]'
 spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
   replicas: 1
   strategy:
     type: Recreate

--- a/deploy/letsencrypt-live/single-namespace/imagestream.yaml
+++ b/deploy/letsencrypt-live/single-namespace/imagestream.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-live/single-namespace/role.yaml
+++ b/deploy/letsencrypt-live/single-namespace/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-staging/cluster-wide/clusterrole.yaml
+++ b/deploy/letsencrypt-staging/cluster-wide/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-staging/cluster-wide/deployment.yaml
+++ b/deploy/letsencrypt-staging/cluster-wide/deployment.yaml
@@ -1,13 +1,15 @@
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openshift-acme
   labels:
     app: openshift-acme
   annotations:
-    image.alpha.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[0].image"}]'
     image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"openshift-acme\")].image"}]'
 spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
   replicas: 1
   strategy:
     type: Recreate

--- a/deploy/letsencrypt-staging/cluster-wide/imagestream.yaml
+++ b/deploy/letsencrypt-staging/cluster-wide/imagestream.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-staging/single-namespace/deployment.yaml
+++ b/deploy/letsencrypt-staging/single-namespace/deployment.yaml
@@ -1,13 +1,15 @@
 kind: Deployment
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: openshift-acme
   labels:
     app: openshift-acme
   annotations:
-    image.alpha.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[0].image"}]'
     image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"openshift-acme:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"openshift-acme\")].image"}]'
 spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
   replicas: 1
   strategy:
     type: Recreate

--- a/deploy/letsencrypt-staging/single-namespace/imagestream.yaml
+++ b/deploy/letsencrypt-staging/single-namespace/imagestream.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: openshift-acme

--- a/deploy/letsencrypt-staging/single-namespace/role.yaml
+++ b/deploy/letsencrypt-staging/single-namespace/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: openshift-acme

--- a/deploy/local-dev/deployment.yaml
+++ b/deploy/local-dev/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sshd

--- a/examples/routes/mydomain.io.yaml
+++ b/examples/routes/mydomain.io.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   annotations:


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
OpenShift 4.1 droped legacy API. (Controller was using/requiring API groups just the manifests were stale.)

**Which issue(s) this PR fixes**:
Fixes https://github.com/tnozicka/openshift-acme/issues/93

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
