### PR TITLE
Use current namespace and not hardcoded

### DIFF
--- a/deploy/.diffs/single_namespace-deployment.yaml.diff
+++ b/deploy/.diffs/single_namespace-deployment.yaml.diff
@@ -1,4 +1,9 @@
 7d6
 <   annotations:
-27a27
->         - --namespace=acme-controller
+27a27,32
+>         - --namespace=$(CURRENT_NAMESPACE)
+>         env:
+>         - name: CURRENT_NAMESPACE
+>           valueFrom:
+>             fieldRef:
+>               fieldPath: metadata.namespace

--- a/deploy/.diffs/specific_namespaces-deployment.yaml.diff
+++ b/deploy/.diffs/specific_namespaces-deployment.yaml.diff
@@ -1,5 +1,10 @@
 7d6
 <   annotations:
-27a27,28
->         - --namespace=acme-controller
+27a27,33
+>         - --namespace=$(CURRENT_NAMESPACE)
 >         - --namespace=test
+>         env:
+>         - name: CURRENT_NAMESPACE
+>           valueFrom:
+>             fieldRef:
+>               fieldPath: metadata.namespace

--- a/deploy/single-namespace/deployment.yaml
+++ b/deploy/single-namespace/deployment.yaml
@@ -24,4 +24,9 @@ spec:
         args:
         - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
         - --loglevel=4
-        - --namespace=acme-controller
+        - --namespace=$(CURRENT_NAMESPACE)
+        env:
+        - name: CURRENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/deploy/specific-namespaces/deployment.yaml
+++ b/deploy/specific-namespaces/deployment.yaml
@@ -24,5 +24,10 @@ spec:
         args:
         - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
         - --loglevel=4
-        - --namespace=acme-controller
+        - --namespace=$(CURRENT_NAMESPACE)
         - --namespace=test
+        env:
+        - name: CURRENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup

**What this PR does / why we need it**:

Better deployment on single-namespace env. You don't have to change the deployment anymore.

Tested on openshift online ( openshift version 3.11 )

**Which issue(s) this PR fixes**:
https://github.com/tnozicka/openshift-acme/issues/115

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Single namespace and specific namespaces deployments now autodetect the controller namespace and don't require changing deployment fixtures for that.
```
