### PR TITLE
Respect limitRanges when creating pods

### DIFF
--- a/deploy/cluster-wide/clusterrole.yaml
+++ b/deploy/cluster-wide/clusterrole.yaml
@@ -51,6 +51,15 @@ rules:
   - patch
 
 - apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
   - "apps"
   resources:
   - replicasets

--- a/deploy/single-namespace/role.yaml
+++ b/deploy/single-namespace/role.yaml
@@ -42,6 +42,15 @@ rules:
   - delete
 
 - apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
   - "apps"
   resources:
   - replicasets

--- a/deploy/specific-namespaces/role.yaml
+++ b/deploy/specific-namespaces/role.yaml
@@ -42,6 +42,15 @@ rules:
   - delete
 
 - apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
   - "apps"
   resources:
   - replicasets

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v0.0.6-0.20191226175542-bf2689566459
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad
+	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/pkg/controller/route/route_test.go
+++ b/pkg/controller/route/route_test.go
@@ -1,12 +1,30 @@
 package route
 
 import (
+	"flag"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/util/errors"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog"
 )
+
+func init() {
+	// Enable klog which is used in dependencies
+	klog.InitFlags(nil)
+	_ = flag.Set("logtostderr", "true")
+	_ = flag.Set("v", "9")
+}
 
 func TestGetTemporaryName(t *testing.T) {
 	tt := []struct {
@@ -38,6 +56,231 @@ func TestGetTemporaryName(t *testing.T) {
 			errs := validation.NameIsDNSSubdomain(r, false)
 			if len(errs) != 0 {
 				t.Errorf("name %q isn't DNS subdomain: %v", r, errs)
+			}
+		})
+	}
+}
+
+func TestAdjustContainerResourceRequirements(t *testing.T) {
+	tt := []struct {
+		name                         string
+		resourceRequirements         *corev1.ResourceRequirements
+		limitRanges                  []*corev1.LimitRange
+		expectedResourceRequirements *corev1.ResourceRequirements
+		expectedErr                  error
+	}{
+		{
+			name: "doesn't change with no LimitRange",
+			resourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			limitRanges: nil,
+			expectedResourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "doesn't change with unrelated LimitRange",
+			resourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("150Mi"),
+				},
+			},
+			limitRanges: []*corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Min: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("25Mi"),
+								},
+								Max: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("300m"),
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+								},
+								MaxLimitRequestRatio: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("3"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("150Mi"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "adjusts min to the LimitRange",
+			resourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			limitRanges: []*corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Min: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("300m"),
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+								},
+								Max: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("300m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("300m"),
+					corev1.ResourceMemory: resource.MustParse("200Mi"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "fails on higher resources then LimitRange max",
+			resourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			limitRanges: []*corev1.LimitRange{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "namespace",
+					},
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypeContainer,
+								Min: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("10Mi"),
+								},
+								Max: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("20m"),
+									corev1.ResourceMemory: resource.MustParse("20Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResourceRequirements: nil,
+			expectedErr: apierrors.NewAggregate([]error{
+				fmt.Errorf("memory ask for 50Mi is higher then maximum memory from limitrange namespace/name"),
+				fmt.Errorf("memory ask for 100Mi is higher then maximum memory from limitrange namespace/name"),
+				fmt.Errorf("cpu ask for 100m is higher then maximum cpu from limitrange namespace/name"),
+				fmt.Errorf("cpu ask for 200m is higher then maximum cpu from limitrange namespace/name"),
+			}),
+		},
+		{
+			name: "adjusts request to the LimitRange request ratio",
+			resourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("1000Mi"),
+				},
+			},
+			limitRanges: []*corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								MaxLimitRequestRatio: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("5"),
+									corev1.ResourceMemory: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResourceRequirements: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("250Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceMemory: resource.MustParse("1000Mi"),
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := adjustContainerResourceRequirements(tc.resourceRequirements, tc.limitRanges)
+
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+			}
+			if err != nil {
+				return
+			}
+
+			if !apiequality.Semantic.DeepEqual(tc.resourceRequirements, tc.expectedResourceRequirements) {
+				t.Errorf("actual ResourceRequirements expected ones, diff: %s", cmp.Diff(tc.expectedResourceRequirements, tc.resourceRequirements))
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Controller must respect range limits when creating pods and setting resource requirements otherwise such pods won't be admitted.

**Which issue(s) this PR fixes**:
Fixes https://github.com/tnozicka/openshift-acme/issues/113

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Controller now respects RangeLimits when creating exposer pods.
```