### PR TITLE
[WIP] Fix eposing for passthrough routes

### DIFF
--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -719,10 +719,7 @@ func (rc *RouteController) sync(ctx context.Context, key string) error {
 				desiredExposerRoute.Labels[api.AcmeExposerUID] = string(routeReadOnly.UID)
 				desiredExposerRoute.Spec.Path = acmeClient.HTTP01ChallengePath(challenge.Token)
 				desiredExposerRoute.Spec.Port = nil
-				desiredExposerRoute.Spec.TLS = &routev1.TLSConfig{
-					Termination:                   "edge",
-					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
-				}
+				desiredExposerRoute.Spec.TLS = nil
 				desiredExposerRoute.Spec.To = routev1.RouteTargetReference{
 					Kind: "Service",
 					Name: tmpName,

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -2,20 +2,48 @@ package route
 
 import (
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func IsAdmitted(route *routev1.Route) bool {
-	admittedSet := false
-	admittedValue := true
-	for _, ingress := range route.Status.Ingress {
-		for _, condition := range ingress.Conditions {
-			if condition.Type == "Admitted" {
-				admittedSet = true
-				if condition.Status != "True" {
-					admittedValue = false
-				}
+	c := FindMostRecentIngressAdmittedCondition(route)
+	return c != nil && c.Status == corev1.ConditionTrue
+}
+
+func FindMostRecentIngressAdmittedCondition(route *routev1.Route) *routev1.RouteIngressCondition {
+	var condition *routev1.RouteIngressCondition
+	for ingressIdx := range route.Status.Ingress {
+		ingress := &route.Status.Ingress[ingressIdx]
+
+		for conditionIdx := range ingress.Conditions {
+			c := &ingress.Conditions[conditionIdx]
+
+			if c.Type != routev1.RouteAdmitted {
+				continue
+			}
+
+			if condition == nil {
+				condition = c
+				continue
+			}
+
+			if c.LastTransitionTime.Time.After(condition.LastTransitionTime.Time) {
+				condition = c
 			}
 		}
 	}
-	return admittedSet && admittedValue
+
+	return condition
+}
+
+func FindMostRecentIngressAdmittedConditionOrUnknown(route *routev1.Route) *routev1.RouteIngressCondition {
+	c := FindMostRecentIngressAdmittedCondition(route)
+	if c == nil {
+		return &routev1.RouteIngressCondition{
+			Type:   routev1.RouteAdmitted,
+			Status: corev1.ConditionUnknown,
+			Reason: "SyntheticUnknownCondition",
+		}
+	}
+	return c
 }

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -1,0 +1,179 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func timePointer(t metav1.Time) *metav1.Time {
+	return &t
+}
+
+func TestFindMostRecentIngressAdmittedCondition(t *testing.T) {
+	tt := []struct {
+		name              string
+		route             *routev1.Route
+		expectedCondition *routev1.RouteIngressCondition
+	}{
+		{
+			name: "empty status",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{},
+			},
+			expectedCondition: nil,
+		},
+		{
+			name: "no conditions present",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{},
+						},
+					},
+				},
+			},
+			expectedCondition: nil,
+		},
+		{
+			name: "single ingress",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:               "foo",
+									LastTransitionTime: timePointer(metav1.Unix(10, 0)),
+								},
+								{
+									Type:               "foo-no-time",
+									LastTransitionTime: nil,
+								},
+								{
+									Type:               routev1.RouteAdmitted,
+									LastTransitionTime: timePointer(metav1.Unix(30, 0)),
+									Message:            "winner",
+								},
+								{
+									Type:               routev1.RouteAdmitted,
+									LastTransitionTime: timePointer(metav1.Unix(20, 0)),
+								},
+								{
+									Type:               "bar",
+									LastTransitionTime: timePointer(metav1.Unix(40, 0)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: &routev1.RouteIngressCondition{
+				Type:               routev1.RouteAdmitted,
+				LastTransitionTime: timePointer(metav1.Unix(30, 0)),
+				Message:            "winner",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			condition := FindMostRecentIngressAdmittedCondition(tc.route)
+
+			if !equality.Semantic.DeepEqual(condition, tc.expectedCondition) {
+				t.Errorf("expected condition differs: %s", cmp.Diff(tc.expectedCondition, condition))
+			}
+		})
+	}
+}
+
+func TestIsAdmitted(t *testing.T) {
+	tt := []struct {
+		name     string
+		route    *routev1.Route
+		expected bool
+	}{
+		{
+			name: "admitted condition missing",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "admitted unknown",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:   routev1.RouteAdmitted,
+									Status: corev1.ConditionUnknown,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "admitted false",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:   routev1.RouteAdmitted,
+									Status: corev1.ConditionFalse,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "admitted true",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:   routev1.RouteAdmitted,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsAdmitted(tc.route)
+
+			if got != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When exposing passthrough routes we can't set TLS or the exposing route won't get admitted. We shouldn't need to set this even normally, as I recall that used to be a hack for old router bug.

https://github.com/openshift/router/blob/d3d2388956e569767be27996cebbcaa60be8930c/pkg/router/controller/hostindex/activation.go#L129-L133

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
OpenShift fixes:
 - [ ] https://github.com/openshift/origin/pull/25676

**Does this PR introduce a user-facing change?**:
```release-note
The controller now supports handling passthrough Routes. 
```
