### PR TITLE
Don't default images as they are now set in CI

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -41,8 +41,6 @@ oc new-project "${PROJECT}" || oc project "${PROJECT}" 2>/dev/null
 
 deploy_file=$( mktemp )
 
-CONTROLLER_IMAGE=${CONTROLLER_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//pipeline:openshift-acme-controller}}
-EXPOSER_IMAGE=${EXPOSER_IMAGE:-${IMAGE_FORMAT//\/stable:\$\{component\}//pipeline:openshift-acme-exposer}}
 cat deploy/$1/deployment.yaml | \
     sed -e "s~quay.io/tnozicka/openshift-acme:controller~${CONTROLLER_IMAGE}~" | \
     sed -e "s~quay.io/tnozicka/openshift-acme:exposer~${EXPOSER_IMAGE}~" | \


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Image names are con constructed in CI config https://github.com/openshift/release/pull/8551 so we can drop it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
