### PR TITLE
Allow configuring default cert RSA key size

### DIFF
--- a/pkg/cmd/openshift-acme-controller/openshift-acme-controller.go
+++ b/pkg/cmd/openshift-acme-controller/openshift-acme-controller.go
@@ -47,6 +47,7 @@ type Options struct {
 	LeaderelectionRetryPeriod   time.Duration
 	CertOrderBackoffInitial     time.Duration
 	CertOrderBackoffMax         time.Duration
+	CertDefaultRSAKeyBitSize    int
 	Namespaces                  []string
 	AcmeOrderTimeout            time.Duration
 
@@ -68,6 +69,7 @@ func NewOptions(streams genericclioptions.IOStreams) *Options {
 		LeaderelectionRetryPeriod:   10 * time.Second,
 		CertOrderBackoffInitial:     5 * time.Minute,
 		CertOrderBackoffMax:         24 * time.Hour,
+		CertDefaultRSAKeyBitSize:    4096,
 
 		Annotation:       api.DefaultTlsAcmeAnnotation,
 		AcmeOrderTimeout: 15 * time.Minute,
@@ -132,6 +134,7 @@ func NewOpenshiftAcmeControllerCommand(streams genericclioptions.IOStreams) *cob
 
 	rootCmd.PersistentFlags().DurationVar(&o.CertOrderBackoffInitial, "cert-order-backoff-initial", o.CertOrderBackoffInitial, "Initial value for the exponential backoff guarding retrying failed orders.")
 	rootCmd.PersistentFlags().DurationVar(&o.CertOrderBackoffMax, "cert-order-backoff-max", o.CertOrderBackoffMax, "The upper limit for for the exponential backoff guarding retrying failed orders.")
+	rootCmd.PersistentFlags().IntVar(&o.CertDefaultRSAKeyBitSize, "cert-default-rsa-key-bit-size", o.CertDefaultRSAKeyBitSize, "The default RSA key bit size for new certificates.")
 
 	rootCmd.PersistentFlags().StringVarP(&o.ExposerImage, "exposer-image", "", o.ExposerImage, "Image to use for exposing tokens for http based validation. (In standard configuration this contains openshift-acme-exposer binary, but the API is generic.)")
 
@@ -336,7 +339,7 @@ func (o *Options) Run(cmd *cobra.Command, streams genericclioptions.IOStreams) e
 
 	ac := acmeissuer.NewAccountController(o.kubeClient, kubeInformersForNamespaces)
 
-	rc := routecontroller.NewRouteController(o.Annotation, o.CertOrderBackoffInitial, o.CertOrderBackoffMax, o.ExposerImage, o.ControllerNamespace, o.kubeClient, kubeInformersForNamespaces, o.routeClient, routeInformersForNamespaces)
+	rc := routecontroller.NewRouteController(o.Annotation, o.CertOrderBackoffInitial, o.CertOrderBackoffMax, o.CertDefaultRSAKeyBitSize, o.ExposerImage, o.ControllerNamespace, o.kubeClient, kubeInformersForNamespaces, o.routeClient, routeInformersForNamespaces)
 
 	kubeInformersForNamespaces.Start(stopCh)
 	routeInformersForNamespaces.Start(stopCh)

--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -71,11 +71,12 @@ var (
 )
 
 type RouteController struct {
-	annotation              string
-	certOrderBackoffInitial time.Duration
-	certOrderBackoffMax     time.Duration
-	exposerImage            string
-	controllerNamespace     string
+	annotation               string
+	certOrderBackoffInitial  time.Duration
+	certOrderBackoffMax      time.Duration
+	certDefaultRSAKeyBitSize int
+	exposerImage             string
+	controllerNamespace      string
 
 	kubeClient                 kubernetes.Interface
 	kubeInformersForNamespaces kubeinformers.Interface
@@ -95,6 +96,7 @@ func NewRouteController(
 	annotation string,
 	certOrderBackoffInitial time.Duration,
 	certOrderBackoffMax time.Duration,
+	certDefaultRSAKeyBitSize int,
 	exposerImage string,
 	controllerNamespace string,
 	kubeClient kubernetes.Interface,
@@ -107,11 +109,12 @@ func NewRouteController(
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 
 	rc := &RouteController{
-		annotation:              annotation,
-		certOrderBackoffInitial: certOrderBackoffInitial,
-		certOrderBackoffMax:     certOrderBackoffMax,
-		exposerImage:            exposerImage,
-		controllerNamespace:     controllerNamespace,
+		annotation:               annotation,
+		certOrderBackoffInitial:  certOrderBackoffInitial,
+		certOrderBackoffMax:      certOrderBackoffMax,
+		certDefaultRSAKeyBitSize: certDefaultRSAKeyBitSize,
+		exposerImage:             exposerImage,
+		controllerNamespace:      controllerNamespace,
 
 		kubeClient:                 kubeClient,
 		kubeInformersForNamespaces: kubeInformersForNamespaces,
@@ -1061,7 +1064,7 @@ func (rc *RouteController) sync(ctx context.Context, key string) error {
 		template := x509.CertificateRequest{
 			DNSNames: []string{routeReadOnly.Spec.Host},
 		}
-		privateKey, err := rsa.GenerateKey(cryptorand.Reader, 4096)
+		privateKey, err := rsa.GenerateKey(cryptorand.Reader, rc.certDefaultRSAKeyBitSize)
 		if err != nil {
 			return fmt.Errorf("failed to generate RSA key: %v", err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Some users want to use 2048 keys for performance or compatibility reasons. This allows having a choice.

**Which issue(s) this PR fixes**:
Fixes https://github.com/tnozicka/openshift-acme/issues/120

**Does this PR introduce a user-facing change?**:
```release-note
--cert-default-rsa-key-bit-size flag allows choosing the default RSA key bit size
```