### PR TITLE
Fix issuer priority sorting

### DIFF
--- a/pkg/controllerutils/controllerutils.go
+++ b/pkg/controllerutils/controllerutils.go
@@ -50,7 +50,7 @@ func getIssuerConfigMapsForObject(obj metav1.ObjectMeta, globalIssuerNamesapce s
 
 	sort.Slice(issuerConfigMaps, func(i, j int) bool {
 		lhs := issuerConfigMaps[i]
-		rhs := issuerConfigMaps[i]
+		rhs := issuerConfigMaps[j]
 
 		lhsPrio := 0
 		lhsPrioString, ok := lhs.Annotations[api.AcmePriorityAnnotation]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I think there is a problem with the `acme.openshift.io/priority` annotation.
The sorting function seems to compare each CertIssuer's priority to itself.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
