### PR TITLE
Poll async

### DIFF
--- a/pkg/controller/route/route.go
+++ b/pkg/controller/route/route.go
@@ -1076,6 +1076,13 @@ func (rc *RouteController) sync(ctx context.Context, key string) error {
 			return fmt.Errorf("failed to generate RSA key: %v", err)
 		}
 
+		route := routeReadOnly.DeepCopy()
+		route.Spec.TLS.Key = string(x509.MarshalPKCS1PrivateKey(privateKey))
+		_, err = rc.routeClient.RouteV1().Routes(routeReadOnly.Namespace).Update(route)
+		if err != nil {
+			return fmt.Errorf("can't update route %s/%s with new private key: %v", routeReadOnly.Namespace, route.Name, err)
+		}
+
 		csr, err := x509.CreateCertificateRequest(cryptorand.Reader, &template, privateKey)
 		if err != nil {
 			return fmt.Errorf("failed to create certificate request: %v", err)
@@ -1095,8 +1102,6 @@ func (rc *RouteController) sync(ctx context.Context, key string) error {
 		if err != nil {
 			return fmt.Errorf("can't convert certificate from DER to PEM: %v", err)
 		}
-
-		route := routeReadOnly.DeepCopy()
 
 		// unfortunatly golang acmeClient.CreateOrderCert waits internally for transitioning state
 		// to valid and we need to reflect it in our state machine because we don't get back
@@ -1138,6 +1143,59 @@ func (rc *RouteController) sync(ctx context.Context, key string) error {
 		// Unfortunately the golang acme lib actively waits in 'CreateOrderCert'
 		// so we can't take the appropriate asynchronous action here.
 		// The logic is included in handling acme.StatusReady
+
+		klog.V(4).Infof("Route %q: Order %q: Certificate available at %q", key, order.URI, order.CertURL)
+
+		privateKey, err := x509.ParsePKCS1PrivateKey([]byte(routeReadOnly.Spec.TLS.Key))
+		if err != nil {
+			return fmt.Errorf("can't find private key for cert: %w", err)
+		}
+
+		der, err := acmeClient.FetchCert(ctx, order.CertURL, true)
+		if err != nil {
+			return fmt.Errorf("can't fetch cert: %w", err)
+		}
+
+		certPemData, err := cert.NewCertificateFromDER(der, privateKey)
+		if err != nil {
+			return fmt.Errorf("can't convert certificate from DER to PEM: %v", err)
+		}
+
+		route := routeReadOnly.DeepCopy()
+
+		// unfortunatly golang acmeClient.CreateOrderCert waits internally for transitioning state
+		// to valid and we need to reflect it in our state machine because we don't get back
+		// into the provisioning phase again after the certs are updated and valid.
+		status.ProvisioningStatus.OrderStatus = acme.StatusValid
+
+		// We are updating the route and to avoid conflicts later we will also update the status together
+		err = setStatus(&route.ObjectMeta, status)
+		if err != nil {
+			return fmt.Errorf("can't set status: %w", err)
+		}
+
+		if route.Spec.TLS == nil {
+			route.Spec.TLS = &routev1.TLSConfig{
+				// Defaults
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				Termination:                   routev1.TLSTerminationEdge,
+			}
+		}
+		route.Spec.TLS.Key = string(certPemData.Key)
+		route.Spec.TLS.Certificate = string(certPemData.Crt)
+
+		// TODO: consider RetryOnConflict with rechecking the managed annotation
+		_, err = rc.routeClient.RouteV1().Routes(routeReadOnly.Namespace).Update(route)
+		if err != nil {
+			return fmt.Errorf("can't update route %s/%s with new certificates: %v", routeReadOnly.Namespace, route.Name, err)
+		}
+
+		err = rc.CleanupExposerObjects(routeReadOnly)
+		if err != nil {
+			klog.Errorf("Can't cleanup exposer objects: %v", err)
+		}
+
+		// We have already updated the status when updating the Route.
 		return nil
 
 	case acme.StatusInvalid:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

Currently, when an order is `ready`, `openshift-acme` calls the go ACME library to submit the CSR and obtain the certificate. The library waits until the certificate is returned. Therefore, if the ACME server takes too long, the library will timeout and no certificate is configured. But the ACME server still creates the certificate and switches the order to `valid`. However, `openshift-acme` does nothing with that, and the certificate is never pushed to the `Route`.

This PR extends the logic to allow obtaining the certificate in `valid` state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
Fixes #
-->
The ability to obtain certificates asynchronously, fixing problems with ACME servers that take longer than the ACME library timeout to generate certificates.

**Special notes for your reviewer**:

Please excuse the crudity of this PR, I didn't have time to build it do scale or to paint it, as this was an emergency fix for our systems. There is some duplicated code and I didn't clean up the comments.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
No
